### PR TITLE
Add byte key to ConnectionStats to uniquely identify connections on host

### DIFF
--- a/pkg/tracer/event_common.go
+++ b/pkg/tracer/event_common.go
@@ -40,25 +40,26 @@ func (c ConnectionStats) String() string {
 		c.Pid, c.Source, c.SPort, c.Dest, c.DPort, c.SendBytes, c.RecvBytes)
 }
 
-func (c ConnectionStats) ByteKey(buffer *bytes.Buffer) error {
+func (c ConnectionStats) ByteKey(buffer *bytes.Buffer) ([]byte, error) {
+	buffer.Reset()
 	// Byte-packing to improve creation speed
 	// PID (32 bits) + SPort (16 bits) + DPort (16 bits) = 64 bits
 	p0 := uint64(c.Pid)<<32 | uint64(c.SPort)<<16 | uint64(c.DPort)
 	if err := binary.Write(buffer, binary.LittleEndian, p0); err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := buffer.WriteString(c.Source); err != nil {
-		return err
+		return nil, err
 	}
 	// Family (8 bits) + Type (8 bits) = 16 bits
 	p1 := uint16(c.Family)<<8 | uint16(c.Type)
 	if err := binary.Write(buffer, binary.LittleEndian, p1); err != nil {
-		return err
+		return nil, err
 	}
 	if _, err := buffer.WriteString(c.Dest); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return buffer.Bytes(), nil
 }
 
 type EventType uint32

--- a/pkg/tracer/event_test.go
+++ b/pkg/tracer/event_test.go
@@ -63,7 +63,7 @@ func BenchmarkUniqueConnKeyByteBufferPacked(b *testing.B) {
 	}
 }
 
-func TestConnStatsByteKeyFieldsAgainstEmpty(t *testing.T) {
+func TestConnStatsByteKey(t *testing.T) {
 	buf := new(bytes.Buffer)
 	for _, test := range []struct {
 		a ConnectionStats

--- a/pkg/tracer/event_test.go
+++ b/pkg/tracer/event_test.go
@@ -64,20 +64,39 @@ func BenchmarkUniqueConnKeyByteBufferPacked(b *testing.B) {
 }
 
 func TestConnStatsByteKeyFieldsAgainstEmpty(t *testing.T) {
-	bufA := new(bytes.Buffer)
-	bufB := new(bytes.Buffer)
-
+	buf := new(bytes.Buffer)
 	for _, test := range []struct {
 		a ConnectionStats
 		b ConnectionStats
 	}{
-		{a: ConnectionStats{Pid: 1}, b: ConnectionStats{}},
-		{a: ConnectionStats{Family: 1}, b: ConnectionStats{}},
-		{a: ConnectionStats{Type: 1}, b: ConnectionStats{}},
-		{a: ConnectionStats{Source: "hello"}, b: ConnectionStats{}},
-		{a: ConnectionStats{Dest: "goodbye"}, b: ConnectionStats{}},
-		{a: ConnectionStats{SPort: 1}, b: ConnectionStats{}},
-		{a: ConnectionStats{DPort: 1}, b: ConnectionStats{}},
+		{
+			a: ConnectionStats{Pid: 1},
+			b: ConnectionStats{},
+		},
+		{
+			a: ConnectionStats{Family: 1},
+			b: ConnectionStats{},
+		},
+		{
+			a: ConnectionStats{Type: 1},
+			b: ConnectionStats{},
+		},
+		{
+			a: ConnectionStats{Source: "hello"},
+			b: ConnectionStats{},
+		},
+		{
+			a: ConnectionStats{Dest: "goodbye"},
+			b: ConnectionStats{},
+		},
+		{
+			a: ConnectionStats{SPort: 1},
+			b: ConnectionStats{},
+		},
+		{
+			a: ConnectionStats{DPort: 1},
+			b: ConnectionStats{},
+		},
 		{
 			a: ConnectionStats{Pid: 1, Family: 0, Type: 1, Source: "a"},
 			b: ConnectionStats{Pid: 1, Family: 0, Type: 1, Source: "b"},
@@ -103,12 +122,13 @@ func TestConnStatsByteKeyFieldsAgainstEmpty(t *testing.T) {
 			b: ConnectionStats{Pid: 1, Dest: "b", Type: 0, DPort: 3},
 		},
 	} {
-		bufA.Reset()
-		bufB.Reset()
-		errA := test.a.ByteKey(bufA)
-		errB := test.b.ByteKey(bufB)
-		assert.NoError(t, errA)
-		assert.NoError(t, errB)
-		assert.NotEqual(t, bufA.Bytes(), bufB.Bytes())
+		var keyA, keyB string
+		if b, err := test.a.ByteKey(buf); assert.NoError(t, err) {
+			keyA = string(b)
+		}
+		if b, err := test.b.ByteKey(buf); assert.NoError(t, err) {
+			keyB = string(b)
+		}
+		assert.NotEqual(t, keyA, keyB)
 	}
 }

--- a/pkg/tracer/event_test.go
+++ b/pkg/tracer/event_test.go
@@ -1,0 +1,114 @@
+package tracer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testConn = ConnectionStats{
+		Pid:       123,
+		Type:      1,
+		Family:    0,
+		Source:    "192.168.0.1",
+		Dest:      "192.168.0.103",
+		SPort:     123,
+		DPort:     35000,
+		SendBytes: 123123,
+		RecvBytes: 312312,
+	}
+)
+
+func BenchmarkUniqueConnKeyString(b *testing.B) {
+	c := testConn
+	for n := 0; n < b.N; n++ {
+		fmt.Sprintf("%d-%d-%d-%s-%d-%s-%d", c.Pid, c.Type, c.Family, c.Source, c.SPort, c.Dest, c.DPort)
+	}
+}
+
+func BenchmarkUniqueConnKeyByteBuffer(b *testing.B) {
+	c := testConn
+	buf := new(bytes.Buffer)
+	for n := 0; n < b.N; n++ {
+		buf.Reset()
+		buf.WriteString(c.Source)
+		buf.WriteString(c.Dest)
+		binary.Write(buf, binary.LittleEndian, c.Pid)
+		binary.Write(buf, binary.LittleEndian, c.Type)
+		binary.Write(buf, binary.LittleEndian, c.Family)
+		binary.Write(buf, binary.LittleEndian, c.SPort)
+		binary.Write(buf, binary.LittleEndian, c.DPort)
+		buf.Bytes()
+	}
+}
+
+func BenchmarkUniqueConnKeyByteBufferPacked(b *testing.B) {
+	c := testConn
+	buf := new(bytes.Buffer)
+	for n := 0; n < b.N; n++ {
+		buf.Reset()
+		// PID (32 bits) + SPort (16 bits) + DPort (16 bits) = 64 bits
+		p0 := uint64(c.Pid)<<32 | uint64(c.SPort)<<16 | uint64(c.DPort)
+		binary.Write(buf, binary.LittleEndian, p0)
+		buf.WriteString(c.Source)
+		// Family (8 bits) + Type (8 bits) = 16 bits
+		p1 := uint16(c.Family)<<8 | uint16(c.Type)
+		binary.Write(buf, binary.LittleEndian, p1)
+		buf.WriteString(c.Dest)
+		buf.Bytes()
+	}
+}
+
+func TestConnStatsByteKeyFieldsAgainstEmpty(t *testing.T) {
+	bufA := new(bytes.Buffer)
+	bufB := new(bytes.Buffer)
+
+	for _, test := range []struct {
+		a ConnectionStats
+		b ConnectionStats
+	}{
+		{a: ConnectionStats{Pid: 1}, b: ConnectionStats{}},
+		{a: ConnectionStats{Family: 1}, b: ConnectionStats{}},
+		{a: ConnectionStats{Type: 1}, b: ConnectionStats{}},
+		{a: ConnectionStats{Source: "hello"}, b: ConnectionStats{}},
+		{a: ConnectionStats{Dest: "goodbye"}, b: ConnectionStats{}},
+		{a: ConnectionStats{SPort: 1}, b: ConnectionStats{}},
+		{a: ConnectionStats{DPort: 1}, b: ConnectionStats{}},
+		{
+			a: ConnectionStats{Pid: 1, Family: 0, Type: 1, Source: "a"},
+			b: ConnectionStats{Pid: 1, Family: 0, Type: 1, Source: "b"},
+		},
+		{
+			a: ConnectionStats{Pid: 1, Dest: "b", Family: 0, Type: 1, Source: "a"},
+			b: ConnectionStats{Pid: 1, Dest: "a", Family: 0, Type: 1, Source: "b"},
+		},
+		{
+			a: ConnectionStats{Pid: 1, Dest: "", Family: 0, Type: 1, Source: "a"},
+			b: ConnectionStats{Pid: 1, Dest: "a", Family: 0, Type: 1, Source: ""},
+		},
+		{
+			a: ConnectionStats{Pid: 1, Dest: "b", Family: 0, Type: 1},
+			b: ConnectionStats{Pid: 1, Family: 0, Type: 1, Source: "b"},
+		},
+		{
+			a: ConnectionStats{Pid: 1, Dest: "b", Family: 1},
+			b: ConnectionStats{Pid: 1, Dest: "b", Type: 1},
+		},
+		{
+			a: ConnectionStats{Pid: 1, Dest: "b", Type: 0, SPort: 3},
+			b: ConnectionStats{Pid: 1, Dest: "b", Type: 0, DPort: 3},
+		},
+	} {
+		bufA.Reset()
+		bufB.Reset()
+		errA := test.a.ByteKey(bufA)
+		errB := test.b.ByteKey(bufB)
+		assert.NoError(t, errA)
+		assert.NoError(t, errB)
+		assert.NotEqual(t, bufA.Bytes(), bufB.Bytes())
+	}
+}


### PR DESCRIPTION
To uniquely identify a network connection on a host, we're using the following fields:
- `Pid + Type + Family + Source + Dest + SPort + DPort`
- Note: This will only be used on the host level, for matching connections from one call of `GetActiveConnections()` to another.

```
goos: darwin
goarch: amd64
pkg: github.com/DataDog/tcptracer-bpf/pkg/tracer
BenchmarkUniqueConnKeyString-4             	 3000000	       430 ns/op
BenchmarkUniqueConnKeyByteBuffer-4         	 5000000	       234 ns/op
BenchmarkUniqueConnKeyByteBufferPacked-4   	20000000	        94.2 ns/op
PASS
ok  	github.com/DataDog/tcptracer-bpf/pkg/tracer	5.156s
```