### PR TITLE
Adding TCP tracing tests (and benchmarks)

### DIFF
--- a/pkg/tracer/tracer_test.go
+++ b/pkg/tracer/tracer_test.go
@@ -1,4 +1,6 @@
-package main
+// +build linux_bpf
+
+package tracer
 
 import (
 	"bufio"
@@ -12,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/tcptracer-bpf/pkg/tracer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,9 +23,9 @@ var (
 	payloadSizes      = []int{2 << 5, 2 << 8, 2 << 10, 2 << 12, 2 << 14, 2 << 15}
 )
 
-func TestTCPSendAndReceiveWithBPF(t *testing.T) {
+func TestTCPSendAndReceive(t *testing.T) {
 	// Enable BPF-based network tracer
-	tr, err := tracer.NewTracer(tracer.DefaultConfig)
+	tr, err := NewTracer(DefaultConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +72,7 @@ func TestTCPSendAndReceiveWithBPF(t *testing.T) {
 
 func TestTCPClosedConnectionsAreCleanedUp(t *testing.T) {
 	// Enable BPF-based network tracer
-	tr, err := tracer.NewTracer(tracer.DefaultConfig)
+	tr, err := NewTracer(DefaultConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +117,7 @@ func TestTCPClosedConnectionsAreCleanedUp(t *testing.T) {
 	doneChan <- struct{}{}
 }
 
-func findConnection(l, r net.Addr, c *tracer.Connections) (*tracer.ConnectionStats, bool) {
+func findConnection(l, r net.Addr, c *Connections) (*ConnectionStats, bool) {
 	for _, conn := range c.Conns {
 		localAddr := fmt.Sprintf("%s:%d", conn.Source, conn.SPort)
 		remoteAddr := fmt.Sprintf("%s:%d", conn.Dest, conn.DPort)
@@ -138,7 +139,7 @@ func BenchmarkTCPEcho(b *testing.B) {
 	runBenchtests(b, "", benchEchoTCP)
 
 	// Enable BPF-based network tracer
-	t, err := tracer.NewTracer(tracer.DefaultConfig)
+	t, err := NewTracer(DefaultConfig)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -152,7 +153,7 @@ func BenchmarkTCPSend(b *testing.B) {
 	runBenchtests(b, "", benchSendTCP)
 
 	// Enable BPF-based network tracer
-	t, err := tracer.NewTracer(tracer.DefaultConfig)
+	t, err := NewTracer(DefaultConfig)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/tests/trace_test.go
+++ b/tests/trace_test.go
@@ -41,6 +41,7 @@ func TestTCPSendAndReceiveWithBPF(t *testing.T) {
 	doneChan := make(chan struct{})
 	server.Run(doneChan)
 
+	// Connect to server
 	c, err := net.DialTimeout("tcp", server.address, 50*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)
@@ -87,6 +88,7 @@ func TestTCPClosedConnectionsAreCleanedUp(t *testing.T) {
 	doneChan := make(chan struct{})
 	server.Run(doneChan)
 
+	// Connect to server
 	c, err := net.DialTimeout("tcp", server.address, 50*time.Millisecond)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/trace_test.go
+++ b/tests/trace_test.go
@@ -13,9 +13,67 @@ import (
 	"time"
 
 	"github.com/DataDog/tcptracer-bpf/pkg/tracer"
+	"github.com/stretchr/testify/assert"
 )
 
 var payloadSizes = []int{2 << 5, 2 << 8, 2 << 10, 2 << 12, 2 << 14, 2 << 15}
+
+func TestTCPSendAndReceiveWithBPF(t *testing.T) {
+	ClientMessageSize := 2 << 8
+	ServerMessageSize := 2 << 15
+
+	// Enable BPF-based network tracer
+	tr, err := tracer.NewTracer(tracer.DefaultConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr.Start()
+	defer tr.Stop()
+
+	// Create TCP Server which sends back ServerMessageSize bytes
+	server := NewServer(func(c net.Conn) {
+		r := bufio.NewReader(c)
+		r.ReadBytes(byte('\n'))
+		c.Write(genPayload(ServerMessageSize))
+		c.Close()
+	})
+	doneChan := make(chan struct{})
+	server.Run(doneChan)
+
+	c, err := net.DialTimeout("tcp", server.address, 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// Write ClientMessageSize to server, and read response
+	if _, err = c.Write(genPayload(ClientMessageSize)); err != nil {
+		t.Fatal(err)
+	}
+	r := bufio.NewReader(c)
+	r.ReadBytes(byte('\n'))
+
+	// Iterate through active connections until we find connection created above, and confirm send + recv counts
+	connectionFound := false
+	connections, err := tr.GetActiveConnections()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, conn := range connections.Conns {
+		localAddr := fmt.Sprintf("%s:%d", conn.Source, conn.SPort)
+		remoteAddr := fmt.Sprintf("%s:%d", conn.Dest, conn.DPort)
+		if localAddr == c.LocalAddr().String() && remoteAddr == c.RemoteAddr().String() {
+			connectionFound = true
+			assert.Equal(t, ClientMessageSize, int(conn.SendBytes))
+			assert.Equal(t, ServerMessageSize, int(conn.RecvBytes))
+		}
+	}
+
+	assert.True(t, connectionFound)
+
+	doneChan <- struct{}{}
+}
 
 func runBenchtests(b *testing.B, prefix string, f func(p int) func(*testing.B)) {
 	for _, p := range payloadSizes {

--- a/tests/trace_test.go
+++ b/tests/trace_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/tcptracer-bpf/pkg/tracer"
+)
+
+var payloadSizes = []int{2 << 5, 2 << 8, 2 << 10, 2 << 12, 2 << 14, 2 << 15}
+
+func runBenchtests(b *testing.B, prefix string, f func(p int) func(*testing.B)) {
+	for _, p := range payloadSizes {
+		name := strings.TrimSpace(strings.Join([]string{prefix, strconv.Itoa(p), "bytes"}, " "))
+		b.Run(name, f(p))
+	}
+}
+
+func BenchmarkTCPEcho(b *testing.B) {
+	runBenchtests(b, "", benchEchoTCP)
+
+	// Enable BPF-based network tracer
+	t, err := tracer.NewTracer(tracer.DefaultConfig)
+	if err != nil {
+		b.Fatal(err)
+	}
+	t.Start()
+	defer t.Stop()
+
+	runBenchtests(b, "eBPF", benchEchoTCP)
+}
+
+func BenchmarkTCPSend(b *testing.B) {
+	runBenchtests(b, "", benchSendTCP)
+
+	// Enable BPF-based network tracer
+	t, err := tracer.NewTracer(tracer.DefaultConfig)
+	if err != nil {
+		b.Fatal(err)
+	}
+	t.Start()
+	defer t.Stop()
+
+	runBenchtests(b, "eBPF", benchSendTCP)
+}
+
+func benchEchoTCP(size int) func(b *testing.B) {
+	payload := genPayload(size)
+	echoOnMessage := func(c net.Conn) {
+		r := bufio.NewReader(c)
+		for {
+			buf, err := r.ReadBytes(byte('\n'))
+			if err == io.EOF {
+				c.Close()
+				return
+			}
+			c.Write(buf)
+		}
+	}
+
+	return func(b *testing.B) {
+		end := make(chan struct{})
+		server := NewServer(echoOnMessage)
+		server.Run(end)
+
+		c, err := net.DialTimeout("tcp", server.address, 50*time.Millisecond)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer c.Close()
+		r := bufio.NewReader(c)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			c.Write(payload)
+			buf, err := r.ReadBytes(byte('\n'))
+
+			if err != nil || len(buf) != len(payload) || !bytes.Equal(payload, buf) {
+				b.Fatalf("Sizes: %d, %d. Equal: %v. Error: %s", len(buf), len(payload), bytes.Equal(payload, buf), err)
+			}
+		}
+		b.StopTimer()
+
+		end <- struct{}{}
+	}
+}
+
+func benchSendTCP(size int) func(b *testing.B) {
+	payload := genPayload(size)
+	dropOnMessage := func(c net.Conn) {
+		r := bufio.NewReader(c)
+		for { // Drop all payloads received
+			_, err := r.Discard(r.Buffered() + 1)
+			if err == io.EOF {
+				c.Close()
+				return
+			}
+		}
+	}
+
+	return func(b *testing.B) {
+		end := make(chan struct{})
+		server := NewServer(dropOnMessage)
+		server.Run(end)
+
+		c, err := net.DialTimeout("tcp", server.address, 50*time.Millisecond)
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer c.Close()
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ { // Send-heavy workload
+			_, err := c.Write(payload)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		b.StopTimer()
+
+		end <- struct{}{}
+	}
+}
+
+func NewServer(onMessage func(c net.Conn)) *Server {
+	return &Server{
+		address:   "127.0.0.1:0",
+		onMessage: onMessage,
+	}
+}
+
+func (s *Server) Run(done chan struct{}) {
+	ln, err := net.Listen("tcp", s.address)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	s.address = ln.Addr().String()
+
+	go func() {
+		<-done
+		ln.Close()
+	}()
+
+	go func() {
+		for {
+			if conn, err := ln.Accept(); err != nil {
+				return
+			} else {
+				s.onMessage(conn)
+			}
+		}
+	}()
+}
+
+type Server struct {
+	address   string
+	onMessage func(c net.Conn)
+}
+
+var letterBytes = []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func genPayload(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		if i == n-1 {
+			b[i] = '\n'
+		} else {
+			b[i] = letterBytes[rand.Intn(len(letterBytes))]
+		}
+	}
+	return b
+}


### PR DESCRIPTION
Adding a few straightforward tests for TCP connection monitoring. I'll add a few more as I go, in later PRs, as well as UDP tests and benchmarks.

```
$ sudo go test -tags 'linux_bpf'
PASS
ok  	github.com/DataDog/tcptracer-bpf/tests	0.278s
```

```
$ sudo go test -bench=. -tags 'linux_bpf'

goos: linux
goarch: amd64
pkg: github.com/DataDog/tcptracer-bpf/tests
BenchmarkTCPEcho/64_bytes         	  100000	     15804 ns/op
BenchmarkTCPEcho/512_bytes        	  100000	     16395 ns/op
BenchmarkTCPEcho/2048_bytes       	  100000	     18102 ns/op
BenchmarkTCPEcho/8192_bytes       	   50000	     28940 ns/op
BenchmarkTCPEcho/32768_bytes      	   20000	     76148 ns/op
BenchmarkTCPEcho/65536_bytes      	   10000	    141743 ns/op
BenchmarkTCPEcho/eBPF_64_bytes    	  100000	     18997 ns/op
BenchmarkTCPEcho/eBPF_512_bytes   	  100000	     19632 ns/op
BenchmarkTCPEcho/eBPF_2048_bytes  	  100000	     21633 ns/op
BenchmarkTCPEcho/eBPF_8192_bytes  	   50000	     34502 ns/op
BenchmarkTCPEcho/eBPF_32768_bytes 	   20000	     90108 ns/op
BenchmarkTCPEcho/eBPF_65536_bytes 	   10000	    176208 ns/op

BenchmarkTCPSend/64_bytes         	 1000000	      1370 ns/op
BenchmarkTCPSend/512_bytes        	 1000000	      3058 ns/op
BenchmarkTCPSend/2048_bytes       	  500000	      3939 ns/op
BenchmarkTCPSend/8192_bytes       	  300000	      7322 ns/op
BenchmarkTCPSend/32768_bytes      	  100000	     18431 ns/op
BenchmarkTCPSend/65536_bytes      	   50000	     33183 ns/op
BenchmarkTCPSend/eBPF_64_bytes    	 1000000	      1961 ns/op
BenchmarkTCPSend/eBPF_512_bytes   	 1000000	      3782 ns/op
BenchmarkTCPSend/eBPF_2048_bytes  	  300000	      5139 ns/op
BenchmarkTCPSend/eBPF_8192_bytes  	  200000	      9150 ns/op
BenchmarkTCPSend/eBPF_32768_bytes 	   50000	     23911 ns/op
BenchmarkTCPSend/eBPF_65536_bytes 	   30000	     43270 ns/op
PASS
ok  	github.com/DataDog/tcptracer-bpf/tests	50.272s
```